### PR TITLE
Redo implementation if 'isRuleType' function

### DIFF
--- a/src/main/scala/com/github/zenpie/macrowave/internal/MacroUtils.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/MacroUtils.scala
@@ -1,7 +1,5 @@
 package com.github.zenpie.macrowave.internal
 
-import java.util.LinkedList
-
 import scala.reflect.macros.whitebox
 
 private[internal] trait MacroUtils {
@@ -15,15 +13,24 @@ private[internal] trait MacroUtils {
   private[internal] val SingletonRuleTpe = typeOf[com.github.zenpie.macrowave.Rule[
     com.github.zenpie.macrowave.::[String, com.github.zenpie.macrowave.HNil]]]
 
+  private[internal] val RuleTpe = typeOf[com.github.zenpie.macrowave.Rule[_]]
+  private[internal] val Rule1Tpe = typeOf[com.github.zenpie.macrowave.Rule1[_]]
+
   private[internal] val validRuleActions = ((0 to 22) map (n => s"RuleAction$n")).toSet
 
-  private[internal] def isRuleTpe(tree: Tree): Boolean = tree match {
-    case tq"$prefix.Rule[$_]" => isMacrowavePackageObj(prefix)
-    case tq"$prefix.Rule1[$_]" => isMacrowavePackageObj(prefix)
-    case tq"Rule[$_]" => true
-    case tq"Rule1[$_]" => true
-    case _ => false
-  }
+  private[internal] def isRuleTpe(tree: Tree): Boolean =
+    if (!tree.isType) false else {
+      val tpe = tree.tpe
+      val tpeArgs = tpe.typeArgs
+
+      val apRule = appliedType(RuleTpe, tpeArgs)
+      val apRule1 = appliedType(Rule1Tpe, tpeArgs)
+
+      val isRule = tpe <:< apRule
+      val isRule1 = tpe <:< apRule1
+
+      isRule || isRule1
+    }
 
   private[internal] def isMacrowavePackageObj(prefix: Tree): Boolean =
     prefix match {

--- a/src/main/scala/com/github/zenpie/macrowave/internal/parser/Rule.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/parser/Rule.scala
@@ -14,3 +14,4 @@ case class Optional(rule: Rule, tpe: TypeId) extends Rule
 case class Transform(rule: Rule, action: ActionId, tpe: TypeId) extends Rule
 case class Terminal(name: String, tpe: TypeId) extends Rule
 case class NonTerminal(name: String, tpe: TypeId) extends Rule
+case class Epsilon(tpe: TypeId) extends Rule

--- a/src/main/scala/com/github/zenpie/macrowave/internal/parser/RuleParser.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/parser/RuleParser.scala
@@ -125,6 +125,8 @@ trait RuleParser extends MacroUtils {
         val x   = helper(r)
         parser.Optional(x, tid)
 
+      case q"$prefix.epsilon" if isMacrowavePackageObj(prefix) =>
+        parser.Epsilon(typeOf(tree))
       case q"$_.this.$nonTerminalName" =>
         val ntName = nonTerminalName.toString()
         val ntTpe  = nonTermTpes(ntName)

--- a/src/main/scala/com/github/zenpie/macrowave/internal/parser/RuleValidation.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/parser/RuleValidation.scala
@@ -18,6 +18,7 @@ object RuleValidation {
     val reachableNonTerminals = mutable.Set.empty[NonTerminalId]
 
     def helper(rule: parser.Rule): Unit = rule match {
+      case parser.Epsilon(_) => ()
       case parser.Concatenate(l, r, _) => helper(l); helper(r)
       case parser.Alternate(l, r, _) => helper(l); helper(r)
       case parser.PClosure(r, _) => helper(r)
@@ -51,6 +52,7 @@ object RuleValidation {
     val generating = mutable.Set.empty[NonTerminalId]
 
     def isGenerating(rule: parser.Rule): Boolean = rule match {
+      case parser.Epsilon(_) => true
       case parser.Concatenate(l, r, _) => isGenerating(l) && isGenerating(r)
       case parser.Alternate(l, r, _) => isGenerating(l) || isGenerating(r)
       case parser.PClosure(r, _) => isGenerating(r)

--- a/src/main/scala/com/github/zenpie/macrowave/package.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/package.scala
@@ -20,13 +20,6 @@ package object macrowave {
   def compileTime: Nothing = throw new UnsupportedOperationException("")
 
 
-  @compileTimeOnly("Calls to function 'token' have to be inside a macro invocation!")
-  implicit def token(regex: RegExp): Token = compileTime
-
-  @compileTimeOnly("Calls to function 'singletonRule' have to be inside a macro invocation!")
-  implicit def singletonRule(token: Token): Rule1[String] = compileTime
-
-
   @compileTimeOnly("Calls to function 'literal' have to be inside a macro invocation!")
   implicit def literal(string: String): RegExp = compileTime
 
@@ -35,6 +28,17 @@ package object macrowave {
 
   @compileTimeOnly("Calls to function 'regex' have to be inside a macro invocation!")
   implicit def regex(regex: Regex): RegExp = compileTime
+
+
+  @compileTimeOnly("Calls to function 'token' have to be inside a macro invocation!")
+  implicit def token(regex: RegExp): Token = compileTime
+
+
+  @compileTimeOnly("Calls to function 'singletonRule' have to be inside a macro invocation!")
+  implicit def singletonRule(token: Token): Rule1[String] = compileTime
+
+  @compileTimeOnly("Calls to function 'epsilon' have to be inside a macro invocation!")
+  def epsilon: Rule[HNil] = compileTime
 
   /*
      TODO: Let SBT do the (here) hardcoded code-generation

--- a/src/test/scala/com/github/zenpie/macrowave/GrammarSpec.scala
+++ b/src/test/scala/com/github/zenpie/macrowave/GrammarSpec.scala
@@ -7,6 +7,39 @@ class GrammarSpec extends FlatSpec with Matchers {
 
   behavior of "A grammar"
 
+  /* operations and rules */
+
+  it should "compile, if it is valid" in {
+    import com.github.zenpie.macrowave._
+    import scala.language.postfixOps
+
+    @grammar class Parser {
+      val DIGIT  = com.github.zenpie.macrowave.regex("[0-9]")
+
+      val NUMBER = token(DIGIT +)
+
+      @start def S: Rule1[String] = (
+          ExplicitRuleType
+        | InferredRuleType
+        | Epsilon
+        | Concat ^^ (_ + _)
+        | Alternative
+        | Optional ^^ (_.toString)
+        | PositiveClosue ^^ ((a, b) => a.toString + b.toString)
+        | Kleene ^^ (_.toString)
+      )
+
+      def ExplicitRuleType: Rule1[String] = NUMBER
+      def InferredRuleType = singletonRule(NUMBER)
+      def Epsilon: Rule1[String] = epsilon ^^ (() => "empty")
+      def Concat: Rule[String :: String :: HNil] = NUMBER ~ NUMBER
+      def Alternative: Rule[String :: HNil] = NUMBER | NUMBER
+      def Optional: Rule[Option[String :: HNil] :: HNil] = NUMBER ?
+      def PositiveClosue: Rule[(String :: HNil) :: List[String :: HNil] :: HNil] = NUMBER +
+      def Kleene: Rule[List[String :: HNil] :: HNil] = NUMBER *
+    }
+  }
+
   /* start-rules */
 
   it should "not compile, if no start-rule is defined" in {


### PR DESCRIPTION
It now handles all cases correctly:
- Detection of inferred types as well as
- explicitly declared function types.

Before this commit only rules with explicitly declared types were detected by the macro.