### PR TITLE
Add mechanism for lifting data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ scalaVersion := "2.11.8"
 
 resolvers += Resolver.sonatypeRepo("releases")
 
+scalacOptions ++= Seq("-deprecation", "-feature")
+
 addCompilerPlugin(
   "org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full
 )

--- a/src/main/scala/com/github/zenpie/macrowave/internal/datalift/LiftCodec.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/datalift/LiftCodec.scala
@@ -1,0 +1,137 @@
+package com.github.zenpie.macrowave.internal.datalift
+
+import java.io.DataOutput
+import java.util
+
+import scala.reflect.macros.whitebox
+import scala.language.implicitConversions
+
+abstract class LiftCodec[@specialized T](val c: whitebox.Context) {
+  import c.universe._
+
+  def encode(stream: DataOutput, value: T): Unit
+
+  def decode(stream: TermName): Tree
+
+}
+
+object LiftCodec {
+
+  implicit def stringCodecFactory: whitebox.Context => LiftCodec[String] =
+    new LiftCodec[String](_) {
+      import c.universe._
+
+      val maxLenOfUTFString = 65535
+
+      override def encode(stream: DataOutput, value: String): Unit = {
+        val chunks = value.grouped(maxLenOfUTFString).toArray
+        stream.writeInt(chunks.length)
+        for (chunk <- chunks) {
+          stream.writeUTF(chunk)
+        }
+      }
+
+      override def decode(stream: TermName): Tree = {
+        val chunkCount = TermName(c.freshName("chunkCount"))
+        val sBuilder = TermName(c.freshName("builder"))
+        val i = TermName(c.freshName("i"))
+
+        q"""
+          {
+            val $chunkCount = $stream.readInt()
+            val $sBuilder   = new _root_.java.lang.StringBuilder()
+            var $i = 0
+
+            while ($i < $chunkCount) {
+              $sBuilder.append($stream.readUTF())
+              $i += 1
+            }
+            $sBuilder.toString()
+          }
+        """
+      }
+  }
+
+  implicit val intArrayCodecFactory: whitebox.Context => LiftCodec[Array[Int]] =
+    { c =>
+      import c.universe._
+      primitiveArrayCodec(c)(_.writeInt(_), stream => q"$stream.readInt()")
+    }
+
+  implicit val longArrayCodecFactory: whitebox.Context => LiftCodec[Array[Long]] =
+    { c =>
+      import c.universe._
+      primitiveArrayCodec(c)(_.writeLong(_), stream => q"$stream.readLong()")
+    }
+
+  implicit val bitsetCodecFactory: whitebox.Context => LiftCodec[util.BitSet] =
+    { c =>
+      val longArrayCodec = LiftCodec.longArrayCodecFactory(c)
+      type ForeignTermName = longArrayCodec.c.universe.TermName
+
+      new LiftCodec[util.BitSet](c) {
+        import c.universe._
+
+        override def encode(stream: DataOutput, value: util.BitSet): Unit = {
+          longArrayCodec.encode(stream, value.toLongArray)
+        }
+
+        override def decode(stream: TermName): Tree = {
+          val longs  = TermName(c.freshName("longs"))
+          val BitSet = q"_root_.java.util.BitSet"
+
+          q"""
+            {
+              val $longs = ${longArrayCodec.decode(stream.asInstanceOf[ForeignTermName]).asInstanceOf[Tree]}
+              $BitSet.valueOf($longs)
+            }
+          """
+        }
+      }
+    }
+
+  private def primitiveArrayCodec[@specialized T <: AnyVal]
+    (c0: whitebox.Context)
+    (writeElement: (DataOutput, T) => Unit,
+     readElement :  c0.universe.TermName => c0.universe.Tree)
+    (implicit tpeTag: c0.universe.TypeTag[T]): LiftCodec[Array[T]] = {
+
+      type ForeignTermName = c0.universe.TermName
+      new LiftCodec[Array[T]](c0) {
+        import c.universe._
+
+        override def encode(stream: DataOutput, value: Array[T]): Unit = {
+          val arrayLength = value.length
+          stream.writeInt(arrayLength)
+          var i = 0
+          while (i < arrayLength) {
+            writeElement(stream, value(i))
+            i += 1
+          }
+        }
+
+        override def decode(stream: TermName): Tree = {
+          val arrayLength = TermName(c.freshName("arrayLength"))
+          val value = TermName(c.freshName("value"))
+          val i = TermName(c.freshName("i"))
+          val tTpe = typeOf[T]
+
+          q"""
+            {
+              val $arrayLength = $stream.readInt()
+              val $value = new Array[$tTpe]($arrayLength)
+              var $i = 0
+
+              while ($i < $arrayLength) {
+                $value($i) = ${readElement(stream.asInstanceOf[ForeignTermName]).asInstanceOf[Tree]}
+                $i += 1
+              }
+
+              $value
+            }
+          """
+        }
+      }
+    }
+
+}

--- a/src/main/scala/com/github/zenpie/macrowave/internal/datalift/LiftResult.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/datalift/LiftResult.scala
@@ -1,0 +1,12 @@
+package com.github.zenpie.macrowave.internal.datalift
+
+/**
+  * Result of lifting multiple values.
+  */
+case class LiftResult[Tree](definitions: Seq[Tree],
+                            private val treeRefs: Map[TreeRef[Tree, Any], Tree]) {
+
+  def lookup[T](ref: TreeRef[Tree, T]): Tree =
+    treeRefs(ref.asInstanceOf[TreeRef[Tree, Any]])
+
+}

--- a/src/main/scala/com/github/zenpie/macrowave/internal/datalift/Lifting.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/datalift/Lifting.scala
@@ -1,0 +1,194 @@
+package com.github.zenpie.macrowave.internal.datalift
+
+import java.io.{ByteArrayOutputStream, DataOutputStream}
+
+import scala.collection.mutable
+import scala.reflect.macros.whitebox
+
+final class Lifting[Plant](val c: whitebox.Context) {
+  import c.universe._
+
+  def lift[T](v: T)(implicit codecFactory: whitebox.Context => LiftCodec[T]): TreeRef[Plant, T] = {
+    val codec   = codecFactory(c)
+    val treeRef = nextTreeRef[T]()
+    liftData += ((treeRef, copyRawData(codec, v)))
+    treeRef
+  }
+
+  def build(): LiftResult[Plant] = {
+    val maxDataSize   = 1 << 13
+    val partArraySize = 1 << 13
+    val maxPartCount  = maxDataSize / partArraySize
+
+    val definitions = mutable.ArrayBuffer.empty[Tree]
+    val treeRefs    = mutable.Map.empty[TreeRef[Plant, _], Plant]
+
+    var objectName: TermName = null
+    var fieldName : TermName = null
+    val fieldDefs = mutable.ListBuffer.empty[Tree]
+    var bufferCursor         = 0
+    var buffer: Array[Byte]  = null
+
+    def freshObjectName(): Unit = {
+      objectName = TermName(c.freshName("LiftedData"))
+    }
+    freshObjectName()
+
+    def freshFieldName(): Unit = {
+      fieldName  = TermName(c.freshName("data"))
+    }
+    freshFieldName()
+
+    def freshBuffer(): Unit = {
+      bufferCursor = 0
+      buffer       = new Array[Byte](partArraySize)
+    }
+    freshBuffer()
+
+    def valDefFromBuffer(): Tree = {
+      val array  = buffer take bufferCursor
+      val valDef = q"val $fieldName: Array[Byte] = $array"
+
+      // force val def to be a static member
+      val flags  = new scala.reflect.internal.Flags
+      val flagMeth = valDef.symbol.getClass.getMethod("setFlag", classOf[Long])
+      flagMeth.setAccessible(true)
+      flagMeth.invoke(valDef.symbol, java.lang.Long.valueOf(flags.STATIC))
+
+      valDef
+    }
+
+    def freshObject(): Tree = {
+      q"private object $objectName { ..$fieldDefs }"
+    }
+
+    def freshContainer(flush: Boolean): Unit = {
+      if (bufferCursor >= partArraySize || (flush && bufferCursor > 0)) {
+        // buffer is full, create a fresh one, but first:
+        //   create val-def from current buffer, save in `fieldDefs`
+        fieldDefs += valDefFromBuffer()
+        freshFieldName()
+        freshBuffer()
+
+        // if now more than `maxPartCount` fieldDefs exist,
+        //   create a new object,
+        //   put collected fieldDefs there, clear collection
+        if (fieldDefs.size >= maxPartCount || flush) {
+          definitions += freshObject()
+          fieldDefs.clear()
+          freshObjectName()
+        }
+      } else {
+        // buffer isn't full, do nothing
+      }
+    }
+
+    for ((ref, RawLiftData(data, codec)) <- liftData) {
+      val dataSize   = data.length
+      var dataCursor = 0
+      def toWrite    = dataSize - dataCursor
+      val stores     = mutable.ListBuffer.empty[Store]
+
+      while (toWrite > 0) {
+        val write = Math.min(toWrite, partArraySize - bufferCursor)
+        System.arraycopy(data, dataCursor, buffer, bufferCursor, write)
+        stores += Store(objectName, fieldName, bufferCursor, write)
+        bufferCursor += write
+        dataCursor   += write
+        freshContainer(flush = false)
+      }
+
+      treeRefs += ((ref, generateUnpackExpression(stores, codec).asInstanceOf[Plant]))
+    }
+    freshContainer(flush = true)
+
+    liftData.clear()
+    LiftResult(
+      definitions.asInstanceOf[Seq[Plant]],
+      treeRefs.toMap.asInstanceOf[Map[TreeRef[Plant, Any], Plant]])
+  }
+
+  private def generateUnpackExpression(stores: mutable.ListBuffer[Store], codec: LiftCodec[Any]): Tree = {
+
+    val dataInput = TermName(c.freshName("dataInput"))
+
+    val ByteArrayInputStream = tq"_root_.java.io.ByteArrayInputStream"
+    val DataInputStream = tq"_root_.java.io.DataInputStream"
+    val InputStream = tq"_root_.java.io.InputStream"
+
+    def fromStream(stream: TermName): Tree = {
+      q"""
+        {
+          val $dataInput = new $DataInputStream($stream)
+
+          ${codec.decode(dataInput.asInstanceOf[codec.c.universe.TermName]).asInstanceOf[Tree]}
+        }
+      """
+    }
+
+    if (stores.size == 1) {
+
+      val rawStream = TermName(c.freshName("rawStream"))
+      val Store(objectNme, fieldNme, offset, length) = stores.head
+
+      q"""
+        {
+          val $rawStream = new $ByteArrayInputStream($objectNme.$fieldNme, $offset, $length)
+
+          ${fromStream(rawStream)}
+        }
+      """
+
+    } else {
+
+      val elements = TermName(c.freshName("elements"))
+      val VectorOfStreams = tq"_root_.java.util.Vector[$InputStream]"
+      val vector = TermName(c.freshName("vector"))
+
+      val vectorAddStms = stores map {
+        case Store(objectNme, fieldNme, offset, length) =>
+          q"$vector.add(new $ByteArrayInputStream($objectNme.$fieldNme, $offset, $length))"
+      }
+
+      val EnumerationOfStreams = tq"_root_.java.util.Enumeration[$InputStream]"
+      val concatStream = TermName(c.freshName("concatStream"))
+      val SequenceInputStream = tq"_root_.java.io.SequenceInputStream"
+
+      q"""
+        {
+          val $vector = new $VectorOfStreams(${stores.size})
+          ..$vectorAddStms
+
+          val $elements = $vector.elements().asInstanceOf[$EnumerationOfStreams]
+          val $concatStream = new $SequenceInputStream($elements)
+
+          ${fromStream(concatStream)}
+        }
+      """
+
+    }
+  }
+
+  private case class RawLiftData(data: Array[Byte], codec: LiftCodec[Any])
+
+  private val liftData = mutable.Map.empty[TreeRef[Plant, _], RawLiftData]
+  private var refIds   = 0
+
+  private def nextTreeRef[T](): TreeRef[Plant, T] = {
+    val ref = TreeRef[Plant, T](refIds)
+    refIds += 1
+    ref
+  }
+
+  private def copyRawData[T](codec: LiftCodec[T], v: T): RawLiftData = {
+    val byteStream = new ByteArrayOutputStream()
+    val dataOutput = new DataOutputStream(byteStream)
+    codec.encode(dataOutput, v)
+    RawLiftData(
+      byteStream.toByteArray,
+      codec.asInstanceOf[LiftCodec[Any]])
+  }
+
+  private case class Store(objectName: TermName, fieldName: TermName, offset: Int, length: Int)
+
+}

--- a/src/main/scala/com/github/zenpie/macrowave/internal/datalift/TreeRef.scala
+++ b/src/main/scala/com/github/zenpie/macrowave/internal/datalift/TreeRef.scala
@@ -1,0 +1,6 @@
+package com.github.zenpie.macrowave.internal.datalift
+
+/**
+  * Reference to a tree, which yields a value of type `T` at runtime.
+  */
+case class TreeRef[Tree, T] private[datalift] (private val id: Int)


### PR DESCRIPTION
The mechanism allows to lift different types of data. The data is packed tightly into byte-arrays.
If the generated byte-array gets to large, it is split into multiple classes, which bypasses the JVM class' and methods' code-size limit of 64k.

Compression of the data isn't implemented, yet. We need to research if we actually need this. As of the current implementation, it should be very easy to implement (user-configurable?) compression.


closes #52

